### PR TITLE
Add Route 53 permission

### DIFF
--- a/obsrvbl-policy.json
+++ b/obsrvbl-policy.json
@@ -15,7 +15,8 @@
                 "rds:Describe*",
                 "rds:List*",
                 "redshift:Describe*",
-                "workspaces:Describe*"
+                "workspaces:Describe*",
+                "route53:List*"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
This PR adds the `route53:List*` permission, which allows for read access to Route 53 data.

CC: @joewing 
