### PR TITLE
Additional AWS regions

### DIFF
--- a/onsetup.py
+++ b/onsetup.py
@@ -39,12 +39,14 @@ FLOWLOGS_GROUP_NAME = 'flowlogsGroup'
 # Known AWS regions
 AWS_REGIONS = {
     'us-east-1',
+    'us-east-2',
     'us-west-1',
     'us-west-2',
     'eu-west-1',
     'eu-central-1',
     'ap-northeast-1',
     'ap-northeast-2',
+    'ap-south-1',
     'ap-southeast-1',
     'ap-southeast-2',
     'sa-east-1',


### PR DESCRIPTION
This PR adds `us-east-2` and `ap-south-1` to the list of supported AWS regions. Both of these support CloudWatch Logs and VPC.