### PR TITLE
Add ca-central-1 region

### DIFF
--- a/onsetup.py
+++ b/onsetup.py
@@ -50,6 +50,7 @@ AWS_REGIONS = {
     'ap-southeast-1',
     'ap-southeast-2',
     'sa-east-1',
+    'ca-central-1',
 }
 
 


### PR DESCRIPTION
This PR is similar to #2; it adds the new [ca-central-1 region](https://aws.amazon.com/blogs/aws/now-open-aws-canada-central-region/).