### PR TITLE
Request cloudwatch permissions

### DIFF
--- a/obsrvbl-policy.json
+++ b/obsrvbl-policy.json
@@ -5,6 +5,8 @@
             "Action": [
                 "autoscaling:Describe*",
                 "cloudtrail:LookupEvents",
+                "cloudwatch:Get*",
+                "cloudwatch:List*",
                 "ec2:Describe*",
                 "elasticache:Describe*",
                 "elasticache:List*",


### PR DESCRIPTION
This PR adds CloudWatch "Get" and "List" to the requested permissions. This is used for monitoring "server-less" services.