### PR TITLE
Authentication log files

### DIFF
--- a/awslogs-policy.json
+++ b/awslogs-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams"
+    ],
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+    ]
+  }
+ ]
+}

--- a/awslogs.conf
+++ b/awslogs.conf
@@ -1,0 +1,14 @@
+[general]
+state_file = /var/awslogs/state/agent-state
+
+[/var/log/secure]
+file = /var/log/secure
+log_group_name = obsrvbl-authlogs
+log_stream_name = {instance_id}
+datetime_format = %b %d %H:%M:%S
+
+[/var/log/auth.log]
+file = /var/log/auth.log
+log_group_name = obsrvbl-authlogs
+log_stream_name = {instance_id}
+datetime_format = %b %d %H:%M:%S


### PR DESCRIPTION
This PR adds a policy document to allow EC2 instances to send logs to CloudWatch logs, and also a [CWL agent configuration file](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html). These are supplemental and not currently required (or used) by the main setup script.