### PR TITLE
Add cloud-init script for CWL agent

### DIFF
--- a/awslogs-setup.sh
+++ b/awslogs-setup.sh
@@ -1,0 +1,4 @@
+!/bin/bash
+curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
+chmod +x ./awslogs-agent-setup.py
+./awslogs-agent-setup.py -n -r us-east-1 -c https://raw.githubusercontent.com/obsrvbl/aws-setup/master/awslogs.conf


### PR DESCRIPTION
This PR adds a cloud-init script for installing the CloudWatch Logs agent at EC2 instance creation.